### PR TITLE
To simplify config methods use derived classes like

### DIFF
--- a/UnitTests/TestContainer.cs
+++ b/UnitTests/TestContainer.cs
@@ -171,6 +171,32 @@ namespace UnitTests
         }
 
         [TestMethod]
+        public void ExecuteLoadOnDerivedClass()
+        {
+            // Arrange
+            const string code =
+@"
+namespace UnitTests
+{
+    public class ExecuteCodeConfigFile : UnitTests.TestContainer.TestConfig
+    {
+        public void Load()
+        {
+            IntMember = 42;
+        }
+    }
+}
+";
+            var config = new TestConfig { IntMember = 41 };
+
+            // Act
+            config.Execute(code, new List<string>());
+
+            // Assert
+            Assert.AreEqual(42, config.IntMember);
+        }
+
+        [TestMethod]
         public void ExecuteCodeWithReference()
         {
             // Arrange


### PR DESCRIPTION
```
public class ExecuteCodeConfigFile : UnitTests.TestContainer.TestConfig
{
    public void Load()
    {
        IntMember = 42;
    }
}
```

so there is no need to use "config." on each line.

Be more strict in method naming using "Load()" only.
This allows local methods within the class.
